### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,5 +34,5 @@ the stubs from a repo. If you want to use the stubs installed locally just turn
 
 ## Links
 
-- http://cloud.spring.io/spring-cloud-static/Camden.SR4/#_stub_runner_boot_application[Stub Runner Boot documentation]
-- http://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html#_tests[Introduction to an opinionated CD pipeline]
+- https://cloud.spring.io/spring-cloud-static/Camden.SR4/#_stub_runner_boot_application[Stub Runner Boot documentation]
+- https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html#_tests[Introduction to an opinionated CD pipeline]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://cloud.spring.io/spring-cloud-static/Camden.SR4/ (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Camden.SR4/ ([https](https://cloud.spring.io/spring-cloud-static/Camden.SR4/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html ([https](https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8081/artifactory/libs-release-local with 1 occurrences